### PR TITLE
Fix sort by media in GUI on VCN4

### DIFF
--- a/crates/amdgpu_top_gui/src/app.rs
+++ b/crates/amdgpu_top_gui/src/app.rs
@@ -502,7 +502,7 @@ impl MyApp {
             }
             if has_vcn_unified {
                 if ui.button(rt_base(format!("{:^5}", fl!("media")))).clicked() {
-                    self.set_fdinfo_sort_type(FdInfoSortType::Encode);
+                    self.set_fdinfo_sort_type(FdInfoSortType::MediaEngine);
                 }
             } else {
                 if ui.button(rt_base(fl!("decode"))).clicked() {


### PR DESCRIPTION
Previously, when running on VCN4, trying to sort by media (encode/decode) in the GUI would not sort properly, instead sorting by PID as if all programs were using 0% media. Now, sorting works properly.
I've tested this on Ryzen 7 7840u (APU) and it now works.