### PR TITLE
JSON_FIFO mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "amdgpu_top_tui",
  "gix",
  "libamdgpu_top",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ libamdgpu_top = { path = "crates/libamdgpu_top", version = "0.6.1" }
 amdgpu_top_tui = { path = "crates/amdgpu_top_tui/", version = "0.6.1", optional = true }
 amdgpu_top_gui = { path = "crates/amdgpu_top_gui/", version = "0.6.1", optional = true }
 amdgpu_top_json = { path = "crates/amdgpu_top_json/", version = "0.6.1", optional = true }
+libc = { version = "0.2.*" }
 
 [build-dependencies]
 gix = { version = "^0.55", default-features = false, optional = true }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ OPTIONS:
        If 0 is specified, it will be an infinite loop. (default: 0)
    -u <u64>, --update-process-index <u64>
        Update interval in seconds of the process index for fdinfo. (default: 5s)
+   --json_fifo, --json-fifo <String>
+       Output JSON formatted data to FIFO (named pipe) for other application and scripts.
 ```
 
 ### Commands for TUI

--- a/crates/amdgpu_top_json/src/lib.rs
+++ b/crates/amdgpu_top_json/src/lib.rs
@@ -126,14 +126,14 @@ impl JsonApp {
             }).to_string();
 
             if let Some(path) = &fifo_path {
-                if let Ok(mut f) = std::fs::OpenOptions::new()
+                let mut f = std::fs::OpenOptions::new()
                     .read(true)
                     .write(true)
                     .open(&path)
-                {
-                    f.write_all(s.as_bytes()).unwrap();
-                    f.flush().unwrap();
-                }
+                    .unwrap();
+
+                f.write_all(s.as_bytes()).unwrap();
+                f.flush().unwrap();
             } else {
                 println!("{s}");
             }

--- a/docs/amdgpu_top.1
+++ b/docs/amdgpu_top.1
@@ -78,7 +78,10 @@ If 0 is specified, it will be an infinite loop.
 .TP
 \f[B]-u\f[R] \f[I]\f[VI]<u64>\f[I]\f[R], \f[B]--update-process-index\f[R] \f[I]\f[VI]<u64>\f[I]\f[R]
 Update interval in seconds of the process index for fdinfo.
-(default: 5s)
+(default: 5s) \f[B]--json_fifo\f[R] \f[I]\f[VI]<String>\f[I]\f[R],
+\f[B]--json-fifo\f[R] \f[I]\f[VI]<String>\f[I]\f[R]
+Output JSON formatted data to FIFO (named pipe) for other application
+and scripts.
 .TP
 \f[B]--apu\f[R], \f[B]--select-apu\f[R]
 Select APU instance.

--- a/docs/man.amdgpu_top.md
+++ b/docs/man.amdgpu_top.md
@@ -49,6 +49,8 @@ The tool displays information gathered from performance counters (GRBM, GRBM2), 
 
 **-u** *`<u64>`*, **\-\-update-process-index** *`<u64>`*
 :   Update interval in seconds of the process index for fdinfo. (default: 5s)
+**\-\-json_fifo** *`<String>`*, **\-\-json-fifo** *`<String>`*
+:   Output JSON formatted data to FIFO (named pipe) for other application and scripts.
 
 **\-\-apu**, **\-\-select-apu**
 :   Select APU instance.

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,5 @@
 use libamdgpu_top::PCI;
 
-const DEFAULT_FIFO_PATH: &str = "/tmp/amdgpu_top.pipe";
-
 pub struct MainOpt {
     pub instance: Option<usize>, // index
     pub refresh_period: u64, // ms
@@ -176,13 +174,15 @@ impl MainOpt {
                     {
                         let s = if let Some(val_str) = args.get(idx+1) {
                             if val_str.starts_with("-") {
-                                String::from(DEFAULT_FIFO_PATH)
+                                eprintln!("missing argument: \"--json-fifo <String>\"");
+                                std::process::exit(1);
                             } else {
                                 skip = true;
                                 String::from(val_str)
                             }
                         } else {
-                            String::from(DEFAULT_FIFO_PATH)
+                            eprintln!("missing argument: \"--json-fifo <String>\"");
+                            std::process::exit(1);
                         };
 
                         opt.app_mode = AppMode::JSON_FIFO(s);

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,4 @@
 use libamdgpu_top::PCI;
-use std::path::PathBuf;
 
 const DEFAULT_FIFO_PATH: &str = "/tmp/amdgpu_top.pipe";
 
@@ -47,7 +46,7 @@ pub enum AppMode {
     #[cfg(feature = "json")]
     JSON,
     #[cfg(feature = "json")]
-    JSON_FIFO(PathBuf),
+    JSON_FIFO(String),
     #[cfg(feature = "tui")]
     SMI,
 }
@@ -175,18 +174,18 @@ impl MainOpt {
                 "--json-fifo" | "--json_fifo" => {
                     #[cfg(feature = "json")]
                     {
-                        let path = if let Some(val_str) = args.get(idx+1) {
+                        let s = if let Some(val_str) = args.get(idx+1) {
                             if val_str.starts_with("-") {
-                                PathBuf::from(DEFAULT_FIFO_PATH)
+                                String::from(DEFAULT_FIFO_PATH)
                             } else {
                                 skip = true;
-                                PathBuf::from(val_str)
+                                String::from(val_str)
                             }
                         } else {
-                            PathBuf::from(DEFAULT_FIFO_PATH)
+                            String::from(DEFAULT_FIFO_PATH)
                         };
 
-                        opt.app_mode = AppMode::JSON_FIFO(path);
+                        opt.app_mode = AppMode::JSON_FIFO(s);
                     }
                     #[cfg(not(feature = "json"))]
                     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,31 +135,24 @@ fn main() {
         #[cfg(feature = "json")]
         AppMode::JSON => unreachable!(),
         #[cfg(feature = "json")]
-        AppMode::JSON_FIFO(path) => {
+        AppMode::JSON_FIFO(path_string) => {
             use std::ffi::CString;
-            use std::os::unix::fs::FileTypeExt;
+            use std::path::PathBuf;
 
-            let create_fifo = if path.exists() {
-                let metadata = std::fs::metadata(&path).unwrap();
+            let path = PathBuf::from(path_string.clone());
 
-                if metadata.file_type().is_fifo() {
-                    false
-                } else {
-                    std::fs::remove_file(&path).unwrap();
-                    true
-                }
-            } else {
-                true
+            if path.exists() {
+                panic!("{path:?} already exists");
             };
 
-            if create_fifo {
-                let bytes = path.clone().into_os_string().into_encoded_bytes();
+            {
+                let bytes = path_string.as_bytes();
                 let fifo_path = CString::new(bytes).unwrap();
 
                 let r = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o644) };
 
                 if r != 0 {
-                    panic!("mkfifo failed.");
+                    panic!("mkfifo failed: {r}, {path:?}");
                 }
             }
 


### PR DESCRIPTION
Add JSON_FIFO mode for reading by other applications and scripts.

However, it is unclear whether applications will actually be developed to use this mode.

```
$ amdgpu_top --json-fifo /tmp/amdgpu_top.pipe &
$ cat /tmp/amdgpu_top.pipe | jq
$ cat /tmp/amdgpu_top.pipe | jq
...
```