### PR TITLE
Update homepage to repository in Cargo.toml('s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "amdgpu_top"
 version = "0.8.0"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/Umio-Yasuno/amdgpu_top"
+repository = "https://github.com/Umio-Yasuno/amdgpu_top"
 authors = ["Umio Yasuno <coelacanth_dream@protonmail.com>"]
 description = """
 Tool to displays AMDGPU usage.

--- a/crates/amdgpu_top_gui/Cargo.toml
+++ b/crates/amdgpu_top_gui/Cargo.toml
@@ -3,7 +3,7 @@ name = "amdgpu_top_gui"
 version = "0.8.0"
 edition = "2021"
 license = "MIT AND OFL-1.1"
-homepage = "https://github.com/Umio-Yasuno/amdgpu_top"
+repository = "https://github.com/Umio-Yasuno/amdgpu_top"
 authors = ["Umio Yasuno <coelacanth_dream@protonmail.com>"]
 description = "GUI Library for amdgpu_top"
 

--- a/crates/amdgpu_top_json/Cargo.toml
+++ b/crates/amdgpu_top_json/Cargo.toml
@@ -3,7 +3,7 @@ name = "amdgpu_top_json"
 version = "0.8.0"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/Umio-Yasuno/amdgpu_top"
+repository = "https://github.com/Umio-Yasuno/amdgpu_top"
 authors = ["Umio Yasuno <coelacanth_dream@protonmail.com>"]
 description = "Library for JSON output function of amdgpu_top"
 

--- a/crates/amdgpu_top_tui/Cargo.toml
+++ b/crates/amdgpu_top_tui/Cargo.toml
@@ -3,7 +3,7 @@ name = "amdgpu_top_tui"
 version = "0.8.0"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/Umio-Yasuno/amdgpu_top"
+repository = "https://github.com/Umio-Yasuno/amdgpu_top"
 authors = ["Umio Yasuno <coelacanth_dream@protonmail.com>"]
 description = "TUI library for amdgpu_top"
 

--- a/crates/libamdgpu_top/Cargo.toml
+++ b/crates/libamdgpu_top/Cargo.toml
@@ -3,7 +3,7 @@ name = "libamdgpu_top"
 version = "0.8.0"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/Umio-Yasuno/amdgpu_top"
+repository = "https://github.com/Umio-Yasuno/amdgpu_top"
 authors = ["Umio Yasuno <coelacanth_dream@protonmail.com>"]
 description = "A library for amdgpu_top"
 


### PR DESCRIPTION
Change `homepage` key to instead use the [repository](https://rust-digger.code-maven.com/about-repository) key for correctly labeling/pointing to the GitHub repo.

This makes location of the source code easier to see Crates.io. 🙂

---

`homepage`キーの代わりに `repository` キーを使うように変更し、GitHub リポジトリへの正しいラベル付け/ポインティングができるようにしました。

これにより、ソースコードの場所がCrates.ioで見やすくなります🙂。