### PR TITLE
lib: Make ROCm install location configurable using ROCM_PATH env-var

### DIFF
--- a/crates/libamdgpu_top/src/lib.rs
+++ b/crates/libamdgpu_top/src/lib.rs
@@ -145,7 +145,12 @@ pub fn get_hw_ip_info_list(
 }
 
 pub fn get_rocm_version() -> Option<String> {
-    std::fs::read_to_string("/opt/rocm/.info/version").ok()?
+    let rocm_path = match std::env::var_os("ROCM_PATH") {
+        Some(v) => v.into_string().unwrap(),
+        None => "/opt/rocm".to_owned()
+    };
+
+    std::fs::read_to_string(rocm_path + "/.info/version").ok()?
         .split('-').next()
         .map(|s| s.to_string())
 }


### PR DESCRIPTION
The purpose of this change is to allow for amdgpu_top to use alternate ROCm installation paths.

Some ROCm users have several versions of ROCm installed on their machines and configure the desired version using the ROCM_PATH environment variable. This variable-name is widely used by tools like pytorch and even by AMD themselves. As of now, amdgpu_top does not respect the environment variable. This change fixes that.