### PR TITLE
json: add timestamp to JSON outputjson: add timestamp (Unix epoch, UTC) to JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### JSON
+ * add `timestamp` (Unix epoch, UTC) to the JSON output for logging
+
 ## 0.11.0 (2025-09-02)
  * fix Appstream metainfo by @malfisya
  * fix the process to get gpu_metrics when resuming from suspended state

--- a/crates/amdgpu_top_json/src/lib.rs
+++ b/crates/amdgpu_top_json/src/lib.rs
@@ -3,7 +3,7 @@
 use libamdgpu_top::{DevicePath, GetNpuMetrics, stat};
 use libamdgpu_top::app::*;
 use serde_json::{json, Value};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::path::PathBuf;
 use std::io::Write;
 
@@ -29,6 +29,17 @@ pub fn amdgpu_top_version() -> Value {
         "major": env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap_or(0),
         "minor": env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap_or(0),
         "patch": env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap_or(0),
+    })
+}
+
+// Unix epoch time (UTC) of the current sample, useful for logging.
+fn unix_timestamp() -> Value {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+
+    json!({
+        "secs": now.as_secs(),
+        "millis": now.as_millis(),
+        "unit": "Unix epoch (UTC)",
     })
 }
 
@@ -156,6 +167,7 @@ impl JsonApp {
             .collect();
 
         json!({
+            "timestamp": unix_timestamp(),
             "period": {
                 "duration": self.duration_time.as_millis(),
                 "unit": "ms",

--- a/docs/sample.json
+++ b/docs/sample.json
@@ -4013,5 +4013,10 @@
   },
   "suspended_devices": [],
   "suspended_devices_len": 0,
+  "timestamp": {
+    "millis": 1749804000000,
+    "secs": 1749804000,
+    "unit": "Unix epoch (UTC)"
+  },
   "title": "amdgpu_top v0.11.2 (git-bde2a21) (debug build)"
 }


### PR DESCRIPTION
Closes #164

Adds a top-level `timestamp` field to the `amdgpu_top --json` output so the stream can be used for logging. Implemented with std `SystemTime`, no new dependency.